### PR TITLE
[IMP] Automagically replace non ascii characters by their ascii equivalent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+unidecode


### PR DESCRIPTION
It turns out that simply ignoring conflicting non-ascii characters is not ok, as it would create issues like:

- D’Artagnan --> DArtagnan
- ABČDE --> ABDE

`unidecode` on the other hand, tries to replace non-ascii characters by their ascii equivalent in a smart way

- D’Artagnan --> D'Artagnan
- ABČDE --> ABCDE